### PR TITLE
Make reassignment messages one liners

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ Supported actions:
 - *open*: includes link with title, event author, mentions of assignees
   and description
 - *approved*: includes link and event author
-- *update of assigness*: includes link, event author, list of previous
-  assigness and mentions of current assignees
+- *update of assigness*: includes link and mentions of current assignees
 - *merged*: includes link and action author
 - *closed*: includes link and action author
 - *reopened*: includes link and action author

--- a/ggci/gitlab.py
+++ b/ggci/gitlab.py
@@ -131,17 +131,10 @@ class MergeRequestEvent:
             text = f'{self.short_link} *merged* by {self.event_author}.'
         elif self.action == Action.UPDATE:
             assert isinstance(self.assignees_change, AssigneesChange)
-            previous = format_users(users=self.assignees_change.previous)
-            current = format_users(
+            current_assignees = format_users(
                 users=self.assignees_change.current, mention=True
             )
-            text = '\n'.join(
-                (
-                    f'{self.short_link} *reassigned* by {self.event_author}',
-                    f'\tPrevious assignees: {previous}',
-                    f'\tCurrent assignees: {current}',
-                )
-            )
+            text = f'{self.short_link} *reassigned* to {current_assignees}'
         elif self.action == Action.CLOSE:
             text = f'{self.short_link} *closed* by {self.event_author}.'
         elif self.action == Action.REOPEN:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ggci"
-version = "0.2.0"
+version = "0.3.0"
 description = "GitLab Google Chat Integration"
 license = "MIT"
 authors = [

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -26,11 +26,9 @@ def test_update(payload_mr_update: Dict[str, Any], monkeypatch):
     message = mr_event.create_message()
 
     assert (
-        '<https://www.gitlab.com/lukany/ggci|!42> *reassigned*' in message.text
-    )
-    assert 'by Chuck Norris' in message.text
-    assert '\tPrevious assignees: Alice, Bob' in message.text
-    assert '\tCurrent assignees: Carl, <users/1004>' in message.text
+        '<https://www.gitlab.com/lukany/ggci|!42> *reassigned*'
+        ' to Carl, <users/1004>'
+    ) in message.text
 
 
 def test_approved(payload_mr_approved: Dict[str, Any]):


### PR DESCRIPTION
Three lines per reassignment consumes a lot of vertical space
on Google Chat.
The list of new (current) assignees is the most important,
the rest can be found out in details of the MR on GitLab.